### PR TITLE
Fix memory corruption bug

### DIFF
--- a/ged_ebp.c
+++ b/ged_ebp.c
@@ -69,7 +69,7 @@ struct ged_event_stage_stack {
 
 
 void _show_stack_entry(const struct ged_event_stage *entry) {
-    fprintf(stderr, "%lu ", entry->stage);
+    fprintf(stderr, "%zu ", entry->stage);
     _show_event(&entry->event);
 }
 void _show_stack(const struct ged_event_stage_stack *stack) {

--- a/pipeline/fixid.c
+++ b/pipeline/fixid.c
@@ -45,7 +45,7 @@ void ged_fixid(GedEvent *event, GedEmitterTemplate *emitter, void *rawstate) {
         if (!val) {
             int n = ged_fixid_digitsneeded(state->length+1);
             val = malloc(n+2);
-            snprintf(val, n+2, "X%lu", state->length+1);
+            snprintf(val, n+2, "X%zu", state->length+1);
             trie_put(state, event->data, val);
             event->flags &= ~GED_OWNS_DATA;
         }
@@ -60,7 +60,7 @@ void ged_fixid(GedEvent *event, GedEmitterTemplate *emitter, void *rawstate) {
 }
 
 void *ged_fixidstate_maker() { 
-    trie *ans = calloc(1, sizeof(ans));
+    trie *ans = calloc(1, sizeof(trie));
     return ans;
 }
 void ged_fixidstate_freer(void *state) { 


### PR DESCRIPTION
Bug is that sizeof pointer was allocated not size of the struct pointed to.

Also fix two compiler warnings where a size_t value was being used with %lu instead of %zu.  On some platforms and compilers sizeof(long) != sizeof(size_t) and in such a case this was a compiler warning.

Signed-off-by: Dave Thaler <dthaler@armidalesoftware.com>